### PR TITLE
Fix typo

### DIFF
--- a/codes/eff_res.m
+++ b/codes/eff_res.m
@@ -192,7 +192,7 @@ if K==0
        %good approximation in very reasonable computation time using the
        %following alternative found here: http://www.cs.cmu.edu/~jkoutis/EffectiveResistances/EffectiveResistances.m
        
-       scale = ceil(log2(NT))/epsilon
+       scale = ceil(log2(NT)/epsilon)
        
        %Auxiliary components
        X_fe=parallel.pool.Constant([sparse(NT,N) X(:,N+1:end)]); 


### PR DESCRIPTION
With the original code `scale` may not evaluate to an interger and the `for` loop fails.